### PR TITLE
feat: Add support for Unleash Context properties

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -204,6 +204,33 @@ test('Should include context fields on request', async () => {
     expect(url.searchParams.get('environment')).toEqual('prod');
 });
 
+test('Should not add property fields when properties is an empty object', async () => {
+    fetchMock.mockResponses(
+        [JSON.stringify(data), { status: 200 }],
+        [JSON.stringify(data), { status: 304 }],
+    );
+    const config: IConfig = {
+        url: 'http://localhost/test',
+        clientKey: '12',
+        appName: 'web',
+        environment: 'prod'
+    };
+    const client = new UnleashClient(config);
+    client.updateContext({
+        properties: {}
+    });
+
+    await client.start();
+
+    jest.advanceTimersByTime(1001);
+
+    const url = new URL(fetchMock.mock.calls[0][0]);
+
+    expect(url.searchParams.get('appName')).toEqual('web');
+    expect(url.searchParams.get('environment')).toEqual('prod');
+    expect(url.searchParams.get('properties')).toBeNull();
+});
+
 test('Should use default environment', async () => {
     fetchMock.mockResponses(
         [JSON.stringify(data), { status: 200 }],

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -172,9 +172,22 @@ test('Should include context fields on request', async () => {
         [JSON.stringify(data), { status: 200 }],
         [JSON.stringify(data), { status: 304 }],
     );
-    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', appName: 'web', environment: 'prod' };
+    const config: IConfig = {
+        url: 'http://localhost/test',
+        clientKey: '12',
+        appName: 'web',
+        environment: 'prod'
+    };
     const client = new UnleashClient(config);
-    client.updateContext({userId: '123', randomField: 'random'});
+    client.updateContext({
+        userId: '123',
+        sessionId: '456',
+        remoteAddress: 'address',
+        properties: {
+            property1: 'property1',
+            property2: 'property2'
+        }
+    });
 
     await client.start();
 
@@ -183,7 +196,10 @@ test('Should include context fields on request', async () => {
     const url = new URL(fetchMock.mock.calls[0][0]);
 
     expect(url.searchParams.get('userId')).toEqual('123');
-    expect(url.searchParams.get('randomField')).toEqual('random');
+    expect(url.searchParams.get('sessionId')).toEqual('456');
+    expect(url.searchParams.get('remoteAddress')).toEqual('address');
+    expect(url.searchParams.get('properties.property1')).toEqual('property1');
+    expect(url.searchParams.get('properties.property2')).toEqual('property2');
     expect(url.searchParams.get('appName')).toEqual('web');
     expect(url.searchParams.get('environment')).toEqual('prod');
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -12,14 +12,14 @@ afterEach(() => {
 });
 
 test('Should inititalize unleash-client', () => {
-    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', context: { appName: 'web' } };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', appName: 'web' };
     const client = new UnleashClient(config);
     expect(config.url).toBe('http://localhost/test');
 });
 
 test('Should perform an inital fetch', async () => {
     fetchMock.mockResponseOnce(JSON.stringify(data));
-    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', context: { appName: 'web' } };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', appName: 'web' };
     const client = new UnleashClient(config);
     await client.start();
     const isEnabled = client.isEnabled('simpleToggle');
@@ -29,7 +29,7 @@ test('Should perform an inital fetch', async () => {
 
 test('Should have correct variant', async () => {
     fetchMock.mockResponseOnce(JSON.stringify(data));
-    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', context: { appName: 'web' } };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', appName: 'web' };
     const client = new UnleashClient(config);
     await client.start();
     const variant = client.getVariant('variantToggle');
@@ -42,7 +42,7 @@ test('Should have correct variant', async () => {
 
 test('Should handle error and return false for isEnabled', async () => {
     fetchMock.mockReject();
-    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', context: { appName: 'web' } };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', appName: 'web' };
     const client = new UnleashClient(config);
     await client.start();
     const isEnabled = client.isEnabled('simpleToggle');
@@ -52,7 +52,7 @@ test('Should handle error and return false for isEnabled', async () => {
 
 test('Should publish ready when inital fetch completed', (done) => {
     fetchMock.mockResponseOnce(JSON.stringify(data));
-    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', context: { appName: 'web' } };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', appName: 'web' };
     const client = new UnleashClient(config);
     client.start();
     client.on(EVENTS.READY, () => {
@@ -68,7 +68,7 @@ test('Should publish update when state changes after refreshInterval', async (do
         [JSON.stringify(data), { status: 200 }],
         [JSON.stringify(data), { status: 200 }],
     );
-    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', refreshInterval: 1, context: { appName: 'web' } };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', refreshInterval: 1, appName: 'web' };
     const client = new UnleashClient(config);
 
     let counts = 0;
@@ -92,7 +92,7 @@ test('Should include etag in second request', async () => {
         [JSON.stringify(data), { status: 200, headers: { ETag: etag} }],
         [JSON.stringify(data), { status: 304, headers: { ETag: etag} }],
     );
-    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', refreshInterval: 1, context: { appName: 'web' } };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', refreshInterval: 1, appName: 'web' };
     const client = new UnleashClient(config);
 
     await client.start();
@@ -108,7 +108,7 @@ test('Should add clientKey as Authorization header', async () => {
         [JSON.stringify(data), { status: 200 }],
         [JSON.stringify(data), { status: 200 }],
     );
-    const config: IConfig = { url: 'http://localhost/test', clientKey: 'some123key', context: { appName: 'web' } };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: 'some123key', appName: 'web' };
     const client = new UnleashClient(config);
     await client.start();
 
@@ -120,28 +120,28 @@ test('Should add clientKey as Authorization header', async () => {
 test('Should require appName', () => {
     expect(() => {
         // tslint:disable-next-line
-        new UnleashClient({ url: 'http://localhost/test', clientKey: '12', context: { appName: '' } })
+        new UnleashClient({ url: 'http://localhost/test', clientKey: '12', appName: '' })
       }).toThrow();
 });
 
 test('Should require url', () => {
     expect(() => {
         // tslint:disable-next-line
-        new UnleashClient({ url: '', clientKey: '12', context: { appName: 'web' } })
+        new UnleashClient({ url: '', clientKey: '12', appName: 'web' })
       }).toThrow();
 });
 
 test('Should require valid url', () => {
     expect(() => {
         // tslint:disable-next-line
-        new UnleashClient({ url: 'not-a-url', clientKey: '12', context: { appName: 'web' } })
+        new UnleashClient({ url: 'not-a-url', clientKey: '12', appName: 'web' })
       }).toThrow();
 });
 
 test('Should require valid clientKey', () => {
     expect(() => {
         // tslint:disable-next-line
-        new UnleashClient({ url: 'http://localhost/test', clientKey: '', context: { appName: 'web' } })
+        new UnleashClient({ url: 'http://localhost/test', clientKey: '', appName: 'web' })
       }).toThrow();
 });
 
@@ -151,7 +151,7 @@ test('Should stop fetching when stop is called', async () => {
         [JSON.stringify(data), { status: 200 }],
         [JSON.stringify(data), { status: 200 }],
     );
-    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', refreshInterval: 1, context: { appName: 'web' } };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', refreshInterval: 1, appName: 'web' };
     const client = new UnleashClient(config);
 
     await client.start();
@@ -175,7 +175,8 @@ test('Should include context fields on request', async () => {
     const config: IConfig = {
         url: 'http://localhost/test',
         clientKey: '12',
-        context: { appName: 'web', environment: 'prod' }
+        appName: 'web',
+        environment: 'prod'
     };
     const client = new UnleashClient(config);
     client.updateContext({
@@ -211,7 +212,8 @@ test('Should not add property fields when properties is an empty object', async 
     const config: IConfig = {
         url: 'http://localhost/test',
         clientKey: '12',
-        context: { appName: 'web', environment: 'prod' },
+        appName: 'web',
+        environment: 'prod'
     };
     const client = new UnleashClient(config);
     client.updateContext({
@@ -234,7 +236,7 @@ test('Should use default environment', async () => {
         [JSON.stringify(data), { status: 200 }],
         [JSON.stringify(data), { status: 200 }],
     );
-    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', context: { appName: 'web' } };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', appName: 'web' };
     const client = new UnleashClient(config);
     await client.start();
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -178,7 +178,7 @@ test('Should include context fields on request', async () => {
         remoteAddress: 'address',
         properties: {
             property1: 'property1',
-            property2: 'property2'
+            property2: 'property2',
         }
     }
     const config: IConfig = {
@@ -199,8 +199,8 @@ test('Should include context fields on request', async () => {
     expect(url.searchParams.get('userId')).toEqual('123');
     expect(url.searchParams.get('sessionId')).toEqual('456');
     expect(url.searchParams.get('remoteAddress')).toEqual('address');
-    expect(url.searchParams.get('properties.property1')).toEqual('property1');
-    expect(url.searchParams.get('properties.property2')).toEqual('property2');
+    expect(url.searchParams.get('properties[property1]')).toEqual('property1');
+    expect(url.searchParams.get('properties[property2]')).toEqual('property2');
     expect(url.searchParams.get('appName')).toEqual('web');
     expect(url.searchParams.get('environment')).toEqual('prod');
 });
@@ -236,8 +236,8 @@ test('Should update context fields on request', async () => {
     expect(url.searchParams.get('userId')).toEqual('123');
     expect(url.searchParams.get('sessionId')).toEqual('456');
     expect(url.searchParams.get('remoteAddress')).toEqual('address');
-    expect(url.searchParams.get('properties.property1')).toEqual('property1');
-    expect(url.searchParams.get('properties.property2')).toEqual('property2');
+    expect(url.searchParams.get('properties[property1]')).toEqual('property1');
+    expect(url.searchParams.get('properties[property2]')).toEqual('property2');
     expect(url.searchParams.get('appName')).toEqual('web');
     expect(url.searchParams.get('environment')).toEqual('prod');
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -12,14 +12,14 @@ afterEach(() => {
 });
 
 test('Should inititalize unleash-client', () => {
-    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', appName: 'web' };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', context: { appName: 'web' } };
     const client = new UnleashClient(config);
     expect(config.url).toBe('http://localhost/test');
 });
 
 test('Should perform an inital fetch', async () => {
     fetchMock.mockResponseOnce(JSON.stringify(data));
-    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', appName: 'web' };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', context: { appName: 'web' } };
     const client = new UnleashClient(config);
     await client.start();
     const isEnabled = client.isEnabled('simpleToggle');
@@ -29,7 +29,7 @@ test('Should perform an inital fetch', async () => {
 
 test('Should have correct variant', async () => {
     fetchMock.mockResponseOnce(JSON.stringify(data));
-    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', appName: 'web' };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', context: { appName: 'web' } };
     const client = new UnleashClient(config);
     await client.start();
     const variant = client.getVariant('variantToggle');
@@ -42,7 +42,7 @@ test('Should have correct variant', async () => {
 
 test('Should handle error and return false for isEnabled', async () => {
     fetchMock.mockReject();
-    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', appName: 'web' };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', context: { appName: 'web' } };
     const client = new UnleashClient(config);
     await client.start();
     const isEnabled = client.isEnabled('simpleToggle');
@@ -52,7 +52,7 @@ test('Should handle error and return false for isEnabled', async () => {
 
 test('Should publish ready when inital fetch completed', (done) => {
     fetchMock.mockResponseOnce(JSON.stringify(data));
-    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', appName: 'web' };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', context: { appName: 'web' } };
     const client = new UnleashClient(config);
     client.start();
     client.on(EVENTS.READY, () => {
@@ -68,7 +68,7 @@ test('Should publish update when state changes after refreshInterval', async (do
         [JSON.stringify(data), { status: 200 }],
         [JSON.stringify(data), { status: 200 }],
     );
-    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', refreshInterval: 1, appName: 'web' };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', refreshInterval: 1, context: { appName: 'web' } };
     const client = new UnleashClient(config);
 
     let counts = 0;
@@ -92,7 +92,7 @@ test('Should include etag in second request', async () => {
         [JSON.stringify(data), { status: 200, headers: { ETag: etag} }],
         [JSON.stringify(data), { status: 304, headers: { ETag: etag} }],
     );
-    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', refreshInterval: 1, appName: 'web' };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', refreshInterval: 1, context: { appName: 'web' } };
     const client = new UnleashClient(config);
 
     await client.start();
@@ -108,7 +108,7 @@ test('Should add clientKey as Authorization header', async () => {
         [JSON.stringify(data), { status: 200 }],
         [JSON.stringify(data), { status: 200 }],
     );
-    const config: IConfig = { url: 'http://localhost/test', clientKey: 'some123key', appName: 'web' };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: 'some123key', context: { appName: 'web' } };
     const client = new UnleashClient(config);
     await client.start();
 
@@ -120,28 +120,28 @@ test('Should add clientKey as Authorization header', async () => {
 test('Should require appName', () => {
     expect(() => {
         // tslint:disable-next-line
-        new UnleashClient({ url: 'http://localhost/test', clientKey: '12', appName: '' })
+        new UnleashClient({ url: 'http://localhost/test', clientKey: '12', context: { appName: '' } })
       }).toThrow();
 });
 
 test('Should require url', () => {
     expect(() => {
         // tslint:disable-next-line
-        new UnleashClient({ url: '', clientKey: '12', appName: 'web' })
+        new UnleashClient({ url: '', clientKey: '12', context: { appName: 'web' } })
       }).toThrow();
 });
 
 test('Should require valid url', () => {
     expect(() => {
         // tslint:disable-next-line
-        new UnleashClient({ url: 'not-a-url', clientKey: '12', appName: 'web' })
+        new UnleashClient({ url: 'not-a-url', clientKey: '12', context: { appName: 'web' } })
       }).toThrow();
 });
 
 test('Should require valid clientKey', () => {
     expect(() => {
         // tslint:disable-next-line
-        new UnleashClient({ url: 'http://localhost/test', clientKey: '', appName: 'web' })
+        new UnleashClient({ url: 'http://localhost/test', clientKey: '', context: { appName: 'web' } })
       }).toThrow();
 });
 
@@ -151,7 +151,7 @@ test('Should stop fetching when stop is called', async () => {
         [JSON.stringify(data), { status: 200 }],
         [JSON.stringify(data), { status: 200 }],
     );
-    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', refreshInterval: 1, appName: 'web' };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', refreshInterval: 1, context: { appName: 'web' } };
     const client = new UnleashClient(config);
 
     await client.start();
@@ -175,8 +175,7 @@ test('Should include context fields on request', async () => {
     const config: IConfig = {
         url: 'http://localhost/test',
         clientKey: '12',
-        appName: 'web',
-        environment: 'prod'
+        context: { appName: 'web', environment: 'prod' }
     };
     const client = new UnleashClient(config);
     client.updateContext({
@@ -212,8 +211,7 @@ test('Should not add property fields when properties is an empty object', async 
     const config: IConfig = {
         url: 'http://localhost/test',
         clientKey: '12',
-        appName: 'web',
-        environment: 'prod'
+        context: { appName: 'web', environment: 'prod' },
     };
     const client = new UnleashClient(config);
     client.updateContext({
@@ -236,7 +234,7 @@ test('Should use default environment', async () => {
         [JSON.stringify(data), { status: 200 }],
         [JSON.stringify(data), { status: 200 }],
     );
-    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', appName: 'web' };
+    const config: IConfig = { url: 'http://localhost/test', clientKey: '12', context: { appName: 'web' } };
     const client = new UnleashClient(config);
     await client.start();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export interface IConfig extends IStaticContext {
     metricsInterval?: number;
     disableMetrics?: boolean;
     storageProvider?: IStorageProvider;
+    context?: IMutableContext;
 }
 
 
@@ -70,7 +71,8 @@ export class UnleashClient extends TinyEmitter {
             metricsInterval = 30,
             disableMetrics = false,
             appName,
-            environment = 'default'}
+            environment = 'default',
+            context}
         : IConfig) {
         super();
         // Validations
@@ -88,7 +90,7 @@ export class UnleashClient extends TinyEmitter {
         this.clientKey = clientKey;
         this.storage = storageProvider || new LocalStorageProvider();
         this.refreshInterval = refreshInterval * 1000;
-        this.context = { appName, environment };
+        this.context = { appName, environment, ...context };
         this.toggles = this.storage.get(storeKey) || [];
         this.metrics = new Metrics({
             appName,

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,11 @@ export class UnleashClient extends TinyEmitter {
             metricsInterval = 30,
             disableMetrics = false,
             environment = 'default',
-            appName}
+            appName,
+            userId,
+            sessionId,
+            remoteAddress,
+            properties}
         : IConfig) {
         super();
         // Validations
@@ -90,7 +94,7 @@ export class UnleashClient extends TinyEmitter {
         this.clientKey = clientKey;
         this.storage = storageProvider || new LocalStorageProvider();
         this.refreshInterval = refreshInterval * 1000;
-        this.context = {environment, appName};
+        this.context = {environment, appName, userId, sessionId, remoteAddress, properties};
         this.toggles = this.storage.get(storeKey) || [];
         this.metrics = new Metrics({
             appName,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,12 @@ export interface IConfig {
     clientKey: string;
     appName: string;
     environment?: string;
+    userId?: string;
+    sessionId?: string;
+    remoteAddress?: string;
+    properties?: {
+        [key:string]: string,
+    };
     refreshInterval?: number;
     metricsInterval?: number;
     disableMetrics?: boolean;
@@ -15,7 +21,14 @@ export interface IConfig {
 }
 
 export interface IContext {
-    [key: string]: string;
+    appName?: string;
+    environment?: string;
+    userId?: string;
+    sessionId?: string;
+    remoteAddress?: string;
+    properties?: {
+        [key:string]: string,
+    };
 }
 
 export interface IVariant {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,8 +19,7 @@ export interface IMutableContext {
 
 export type IContext = IStaticContext & IMutableContext;
 
-export interface IConfig {
-    context: IContext;
+export interface IConfig extends IStaticContext {
     url: string;
     clientKey: string;
     refreshInterval?: number;
@@ -70,7 +69,8 @@ export class UnleashClient extends TinyEmitter {
             refreshInterval = 30,
             metricsInterval = 30,
             disableMetrics = false,
-            context}
+            appName,
+            environment = 'default'}
         : IConfig) {
         super();
         // Validations
@@ -80,21 +80,18 @@ export class UnleashClient extends TinyEmitter {
         if (!clientKey) {
             throw new Error('clientKey is required');
         }
-        if (!context.appName) {
+        if (!appName) {
             throw new Error('appName is required.');
-        }
-        if (!context.environment) {
-            context.environment = 'default';
         }
 
         this.url = new URL(`${url}`);
         this.clientKey = clientKey;
         this.storage = storageProvider || new LocalStorageProvider();
         this.refreshInterval = refreshInterval * 1000;
-        this.context = {...context};
+        this.context = { appName, environment };
         this.toggles = this.storage.get(storeKey) || [];
         this.metrics = new Metrics({
-            appName: context.appName,
+            appName,
             metricsInterval,
             disableMetrics,
             url,

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,7 +170,7 @@ export class UnleashClient extends TinyEmitter {
                 Object.entries(context).forEach(([contextKey, contextValue]) => {
                     if (contextKey === 'properties' && contextValue) {
                         Object.entries<string>(contextValue).forEach(([propertyKey, propertyValue]) =>
-                            urlWithQuery.searchParams.append(`properties.${propertyKey}`, propertyValue)
+                            urlWithQuery.searchParams.append(`properties[${propertyKey}]`, propertyValue)
                         );
                     } else {
                         urlWithQuery.searchParams.append(contextKey, contextValue);

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,7 +162,18 @@ export class UnleashClient extends TinyEmitter {
             try {
                 const context = this.context;
                 const urlWithQuery = new URL(this.url.toString());
-                Object.keys(context).forEach((key) => urlWithQuery.searchParams.append(key, context[key]));
+                // Add context information to url search params. If the properties
+                // object is included in the context, flatten it into the search params
+                // e.g. /?...&property.param1=param1Value&property.param2=param2Value
+                Object.entries(context).forEach((contextEntry) => {
+                    if (contextEntry[0] === 'properties' && contextEntry[1]) {
+                        Object.entries<string>(contextEntry[1]).forEach((propertyEntry) =>
+                            urlWithQuery.searchParams.append(`properties.${propertyEntry[0]}`, propertyEntry[1])
+                        );
+                    } else {
+                        urlWithQuery.searchParams.append(contextEntry[0], contextEntry[1]);
+                    }
+                });
                 const response = await fetch(urlWithQuery.toString(), {
                     cache: 'no-cache',
                     headers: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -165,13 +165,13 @@ export class UnleashClient extends TinyEmitter {
                 // Add context information to url search params. If the properties
                 // object is included in the context, flatten it into the search params
                 // e.g. /?...&property.param1=param1Value&property.param2=param2Value
-                Object.entries(context).forEach((contextEntry) => {
-                    if (contextEntry[0] === 'properties' && contextEntry[1]) {
-                        Object.entries<string>(contextEntry[1]).forEach((propertyEntry) =>
-                            urlWithQuery.searchParams.append(`properties.${propertyEntry[0]}`, propertyEntry[1])
+                Object.entries(context).forEach(([contextKey, contextValue]) => {
+                    if (contextKey === 'properties' && contextValue) {
+                        Object.entries<string>(contextValue).forEach(([propertyKey, propertyValue]) =>
+                            urlWithQuery.searchParams.append(`properties.${propertyKey}`, propertyValue)
                         );
                     } else {
-                        urlWithQuery.searchParams.append(contextEntry[0], contextEntry[1]);
+                        urlWithQuery.searchParams.append(contextKey, contextValue);
                     }
                 });
                 const response = await fetch(urlWithQuery.toString(), {

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,6 +120,12 @@ export class UnleashClient extends TinyEmitter {
     }
 
     public updateContext(context: IMutableContext) {
+        // Give the user a nicer error message when including
+        // static fields in the mutable context object
+        // @ts-ignore
+        if (context.appName || context.environment) {
+            console.warn("appName and environment are static. They can't be updated with updateContext.");
+        }
         const staticContext = {environment: this.context.environment, appName: this.context.appName};
         this.context = {...staticContext, ...context};
         if (this.timerRef) {


### PR DESCRIPTION
Fixes #14 
Now, the IContext is an object of arbitrary key value pairs. Extend this to implement the Unlease Context (https://www.unleash-hosted.com/docs/the-unleash-context)

and fixes #3 
We want to allow a consumer of the UnleashClient to be able to send the properties field, as mentioned in the Unlease Context. This allows them to support custom activation strategies. In this PR I flatten the properties into the url search params, so a properties object like
```
properties: {
  property1: 'property1Value',
  property2: 'property2Value'
}
```
would yield url search params `properties.property1=property1Value&properties.property2=property2Value`